### PR TITLE
add setting the timeout value functionality for runner

### DIFF
--- a/go/logictest/harness.go
+++ b/go/logictest/harness.go
@@ -40,4 +40,7 @@ type Harness interface {
 	// err: queries are never expected to return errors, so any error returned is counted as a failure.
 	// For more information, see: https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki
 	ExecuteQuery(statement string) (schema string, results []string, err error)
+
+	// GetTimeout returns timeout defined in the harness. The value is in seconds.
+	GetTimeout() int64
 }

--- a/go/logictest/mysql/mysqlharness.go
+++ b/go/logictest/mysql/mysqlharness.go
@@ -1,4 +1,3 @@
-
 // Copyright 2019-2020 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +37,7 @@ func NewMysqlHarness(dsn string) *MysqlHarness {
 	if err != nil {
 		panic(err)
 	}
-	return &MysqlHarness{db:db}
+	return &MysqlHarness{db: db}
 }
 
 // See Harness.EngineStr
@@ -89,6 +88,10 @@ func (h *MysqlHarness) ExecuteQuery(statement string) (schema string, results []
 	}
 
 	return schema, results, nil
+}
+
+func (h *MysqlHarness) GetTimeout() int64 {
+	return 0
 }
 
 func (h *MysqlHarness) dropAllTables() error {
@@ -156,7 +159,6 @@ func (h *MysqlHarness) dropAllViews() error {
 
 	return nil
 }
-
 
 // Returns the string representation of the column value given
 func stringVal(col interface{}) string {

--- a/go/logictest/runner.go
+++ b/go/logictest/runner.go
@@ -42,6 +42,8 @@ var startTime time.Time
 var timeout atomic.Int64
 var testTimeoutError = errors.New("test in file timed out")
 
+// SetTimeout sets the global variable, |timeout|.
+// It's not used, the logictest uses the default timeout of 20min.
 func SetTimeout(d time.Duration) {
 	timeout.Store(d.Milliseconds())
 }

--- a/go/logictest/runner.go
+++ b/go/logictest/runner.go
@@ -48,6 +48,11 @@ func SetTimeout(d time.Duration) {
 	timeout.Store(d.Milliseconds())
 }
 
+// GetCurrentFileName returns path to the test file that is currently executing.
+func GetCurrentFileName() string {
+	return testFilePath(currTestFile)
+}
+
 // RunTestFiles runs the test files found under any of the paths given. Can specify individual test files, or directories that
 // contain test files somewhere underneath. All files named *.test encountered under a directory will be attempted to be
 // parsed as a test file, and will panic for malformed test files or paths that don't exist.


### PR DESCRIPTION
Adds feature to use timeout defined in the harness and get name of the test file that's currently running.