### PR TITLE
fix missing empty result set in last query of test file

### DIFF
--- a/test/index/commute/10/slt_good_10.test
+++ b/test/index/commute/10/slt_good_10.test
@@ -26510,3 +26510,4 @@ SELECT pk FROM tab3 WHERE ((60.6 < col4 AND 32 > col3 AND ((53 > col0) OR 54 > c
 
 query I rowsort label-4220
 SELECT pk FROM tab4 WHERE ((col4 > 60.6 AND col3 < 32 AND ((col0 < 53) OR col0 < 54)))
+----


### PR DESCRIPTION
The very last query of this file expects an empty result set.
However, the parser expects a `----` delimiter; without it, we query an empty string, causing an error.

This fixes 1 sqllogictest.