### PR TITLE
Updates for PostgreSQL testing

### DIFF
--- a/go/logictest/runner.go
+++ b/go/logictest/runner.go
@@ -20,6 +20,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -412,8 +413,11 @@ func execute(ctx context.Context, harness Harness, record *parser.Record) (schem
 			return "", nil, true, err
 		}
 
-		// Only log one error per record, so if schema comparison fails don't bother with result comparison
-		if verifySchema(ctx, record, schemaStr) {
+		// Only log one error per record, so if schema comparison fails don't bother with result comparison.
+		// When both the expected and actual result sets are empty, skip the schema check, since SQLite returns
+		// SQLITE_NULL for every column when the result set is empty.
+		emptyResult := record.NumResults() == 0 && len(results) == 0
+		if emptyResult || verifySchema(ctx, record, schemaStr) {
 			verifyResults(ctx, record, schemaStr, results)
 		}
 		return schemaStr, results, true, nil
@@ -445,6 +449,10 @@ func verifyResults(ctx context.Context, record *parser.Record, schema string, re
 // the type of the expression `- - - 8` is decimal (float) as of MySQL 8.0. Rather than expect all databases to
 // duplicate these semantics, we allow integer types to be freely converted to floats. This means we need to format
 // integer results as float results, with three trailing zeros, where necessary.
+//
+// We also handle the reverse: SQLite-generated tests sometimes mark a column as I (integer) for expressions that
+// PostgreSQL (correctly) returns as float. When the expected type is I and the actual result is a whole-number float
+// (e.g., "3.000"), we coerce it to integer format ("3") so the value comparison succeeds.
 func normalizeResults(results []string, schema string) []string {
 	newResults := make([]string, len(results))
 	for i := range results {
@@ -453,6 +461,16 @@ func normalizeResults(results []string, schema string) []string {
 			_, err := strconv.Atoi(results[i])
 			if err == nil {
 				newResults[i] = results[i] + ".000"
+				continue
+			}
+		}
+		// When the test expects an integer but the engine returned a float, coerce to integer
+		// if and only if the value is a whole number. Non-whole floats remain as-is and will
+		// fail the comparison — they represent a genuine semantic difference.
+		if typ == 'I' && strings.Contains(results[i], ".") {
+			f, err := strconv.ParseFloat(results[i], 64)
+			if err == nil && math.Trunc(f) == f {
+				newResults[i] = fmt.Sprintf("%d", int64(f))
 				continue
 			}
 		}
@@ -527,11 +545,16 @@ func verifySchema(ctx context.Context, record *parser.Record, schemaStr string) 
 
 func compatibleSchemaTypes(expected, actual rune) bool {
 	if expected != actual {
+		// Allow integer results where a float is expected (and vice versa): SQLite-generated
+		// tests encode the schema based on SQLite's type affinity, which differs from
+		// MySQL and PostgreSQL. normalizeResults handles value coercion for both directions.
 		if expected == 'R' && actual == 'I' {
 			return true
-		} else {
-			return false
 		}
+		if expected == 'I' && actual == 'R' {
+			return true
+		}
+		return false
 	}
 	return true
 }

--- a/go/logictest/runner.go
+++ b/go/logictest/runner.go
@@ -38,6 +38,20 @@ var currRecord *parser.Record
 var _, TruncateQueriesInLog = os.LookupEnv("SQLLOGICTEST_TRUNCATE_QUERIES")
 
 var startTime time.Time
+
+// runStateKey is a context key for per-goroutine state during concurrent test execution.
+type runStateKey struct{}
+
+// outputMuKey is a context key for the shared output mutex during concurrent test execution.
+type outputMuKey struct{}
+
+// runState holds per-goroutine state needed for logging in concurrent test execution.
+type runState struct {
+	testFile  string
+	record    *parser.Record
+	startTime time.Time
+}
+
 var testTimeoutError = errors.New("test in file timed out")
 
 // GetCurrentFileName returns path to the test file that is currently executing.
@@ -537,44 +551,65 @@ func logResult(ctx context.Context, rt ResultType, message string, args ...inter
 
 	switch rt {
 	case Ok:
-		logSuccess()
+		logSuccess(ctx)
 	case NotOk:
-		logFailure(message, args...)
+		logFailure(ctx, message, args...)
 	case Skipped:
-		logSkip()
+		logSkip(ctx)
 	case Timeout:
-		logTimeout()
+		logTimeout(ctx)
 	case DidNotRun:
-		logDidNotRun()
+		logDidNotRun(ctx)
 	}
 
 	lock.logged = true
 }
 
-func logFailure(message string, args ...interface{}) {
-	newMsg := logMessagePrefix() + " not ok: " + message
+// printLine writes a log line to stdout. When an outputMuKey mutex is present in ctx
+// (set by RunTestFilesConcurrently) it serializes writes across goroutines.
+func printLine(ctx context.Context, line string) {
+	if mu, ok := ctx.Value(outputMuKey{}).(*sync.Mutex); ok && mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	fmt.Println(line)
+}
+
+func logFailure(ctx context.Context, message string, args ...interface{}) {
+	newMsg := logMessagePrefix(ctx) + " not ok: " + message
 	failureMessage := fmt.Sprintf(newMsg, args...)
 	failureMessage = strings.ReplaceAll(failureMessage, "\n", " ")
-	fmt.Println(failureMessage)
+	printLine(ctx, failureMessage)
 }
 
-func logSkip() {
-	fmt.Println(logMessagePrefix(), "skipped")
+func logSkip(ctx context.Context) {
+	printLine(ctx, logMessagePrefix(ctx)+" skipped")
 }
 
-func logSuccess() {
-	fmt.Println(logMessagePrefix(), "ok")
+func logSuccess(ctx context.Context) {
+	printLine(ctx, logMessagePrefix(ctx)+" ok")
 }
 
-func logTimeout() {
-	fmt.Println(logMessagePrefix(), "timeout")
+func logTimeout(ctx context.Context) {
+	printLine(ctx, logMessagePrefix(ctx)+" timeout")
 }
 
-func logDidNotRun() {
-	fmt.Println(logMessagePrefix(), "did not run")
+func logDidNotRun(ctx context.Context) {
+	printLine(ctx, logMessagePrefix(ctx)+" did not run")
 }
 
-func logMessagePrefix() string {
+// logMessagePrefix returns the standard log line prefix. When a runStateKey is present in ctx
+// (set by runTestFileConcurrent) it reads from per-goroutine state; otherwise it falls back to
+// the package-level globals used by the serial RunTestFiles path.
+func logMessagePrefix(ctx context.Context) string {
+	if state, ok := ctx.Value(runStateKey{}).(*runState); ok && state != nil {
+		return fmt.Sprintf("%s %d %s:%d: %s",
+			time.Now().Format(time.RFC3339Nano),
+			time.Since(state.startTime).Milliseconds(),
+			testFilePath(state.testFile),
+			state.record.LineNum(),
+			truncateQuery(state.record.Query()))
+	}
 	return fmt.Sprintf("%s %d %s:%d: %s",
 		time.Now().Format(time.RFC3339Nano),
 		time.Now().Sub(startTime).Milliseconds(),
@@ -605,4 +640,79 @@ func truncateQuery(query string) string {
 		return query[:47] + "..."
 	}
 	return query
+}
+
+// RunTestFilesConcurrently runs the test files found under paths using up to workers goroutines in
+// parallel. makeHarness is called once per worker goroutine; that harness instance handles multiple
+// test files sequentially within the goroutine. A channel-based queue provides natural load
+// balancing so workers pull the next file as soon as they finish the current one.
+//
+// Output lines are serialized with a shared mutex so concurrent goroutines do not interleave
+// partial lines. The log format is identical to RunTestFiles and can be parsed by ParseResultFile.
+func RunTestFilesConcurrently(makeHarness func() Harness, workers int, paths ...string) {
+	testFiles := collectTestFiles(paths)
+
+	queue := make(chan string, len(testFiles))
+	for _, f := range testFiles {
+		queue <- f
+	}
+	close(queue)
+
+	outMu := &sync.Mutex{}
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h := makeHarness()
+			for file := range queue {
+				runTestFileConcurrent(h, file, outMu)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func runTestFileConcurrent(harness Harness, file string, outMu *sync.Mutex) {
+	err := harness.Init()
+	if err != nil {
+		panic(err)
+	}
+
+	testRecords, err := parser.ParseTestFile(file)
+	if err != nil {
+		panic(err)
+	}
+
+	curTimeout := defaultTimeout
+	if t := harness.GetTimeout(); t != 0 {
+		curTimeout = time.Second * time.Duration(t)
+	}
+
+	state := &runState{testFile: file}
+	dnr := false
+	for _, record := range testRecords {
+		state.record = record
+		state.startTime = time.Now()
+
+		baseCtx := context.WithValue(context.Background(), runStateKey{}, state)
+		baseCtx = context.WithValue(baseCtx, outputMuKey{}, outMu)
+		ctx, cancel := context.WithTimeout(baseCtx, curTimeout)
+		lockCtx := context.WithValue(ctx, "lock", &loggingLock{})
+
+		if dnr {
+			logResult(lockCtx, DidNotRun, "")
+			cancel()
+			continue
+		}
+
+		_, _, cont, err := executeRecord(lockCtx, cancel, harness, record)
+		if err == testTimeoutError {
+			dnr = true
+		}
+
+		if !cont {
+			break
+		}
+	}
 }


### PR DESCRIPTION
Adds support for running tests in parallel and makes small changes to support running tests against PostgreSQL database (e.g. flexibility between float and integer return types as long as values match exactly, and skipping return type validation when there are no expected results and no actual results).